### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:lts-alpine
+
+WORKDIR /usr/src/app
+
+RUN addgroup -S tfm
+
+RUN adduser -S -D -h /usr/src/app tfm tfm
+
+RUN chown -R tfm:tfm /usr/src/app
+
+USER tfm
+
+COPY package*.json ./
+
+RUN npm install
+
+EXPOSE 8080
+
+COPY . .
+
+CMD [ "npm", "run", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+terraforming-mars:
+  image: lotooo/terraforming-mars
+  container_name: terraforming-mars
+  labels:
+    - "traefik.frontend.rule=Host:terraforming-mars.mydomain.com"
+    - "traefik.port=8080"
+    - "traefik.protocol=http"
+    - "traefik.backend=terraforming-mars"
+    - "com.centurylinklabs.watchtower.enable=true"

--- a/server.ts
+++ b/server.ts
@@ -64,6 +64,7 @@ function requestHandler(
       } else if (req.url.startsWith('/api/waitingfor?id=')) {
         apiGetWaitingFor(req, res);
       } else if (req.url === '/styles.css') {
+        res.setHeader('Content-Type', 'text/css');
         serveResource(res, styles);
       } else if (
           req.url.startsWith('/assets/') ||


### PR DESCRIPTION
This PR adds a `Dockerfile` and a `docker-compose.yml` to help build and run the app anywhere.

The docker-compose file currently points to an auto-triggered build on hub.docker.com (which automatically update `lotooo/terraforming-mars:latest` tag after each commit on master of this fork.