### PR TITLE
[Feature] Adding saves to allow undo action (#443)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules/
 .nyc_output/
 styles.css
 .vscode/symbols.json
+db/*
 assets/translations.json

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "dialog-polyfill": "^0.5.0",
     "less": "^3.10.3",
     "spectre.css": "^0.5.8",
+    "sqlite3": "^4.1.1",
     "typescript": "^3.5.0",
     "vue": "^2.6.10",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.0"
   },
   "devDependencies": {
+    "@types/sqlite3": "^3.1.6",
     "@typescript-eslint/eslint-plugin": "^2.6.1",
     "@typescript-eslint/parser": "^2.6.1",
     "chai": "^4.2.0",

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -392,7 +392,10 @@ import { RedSpotObservatory } from "./cards/colonies/RedSpotObservatory";
 import { MarketManipulation } from "./cards/colonies/MarketManipulation";
 import { MartianZoo } from "./cards/colonies/MartianZoo";
 
+import { ILoadable } from "./ILoadable";
 import { CardName } from "./CardName";
+import { BeginnerCorporation } from "./cards/corporation/BeginnerCorporation";
+import { SerializedDealer } from "./SerializedDealer";
 
 export interface ICardFactory<T> {
     cardName: CardName;
@@ -815,7 +818,64 @@ export const ALL_PROJECT_CARDS: Array<ICardFactory<IProjectCard>> = [
     { cardName: CardName.ZEPPELINS, factory: Zeppelins }
 ];
 
-export class Dealer {
+// Function to return a card object by its name
+export function getProjectCardByName(cardName: string): IProjectCard | undefined {
+    let cardFactory = ALL_PRELUDE_CARDS.find((cardFactory) => cardFactory.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_PRELUDE_PROJECTS_CARDS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_VENUS_PROJECTS_CARDS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_COLONIES_PROJECTS_CARDS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_PROJECT_CARDS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    return undefined;
+}
+
+// Function to return a corporation card object by its name
+export function getCorporationCardByName(cardName: string): CorporationCard | undefined {
+    if (cardName === (new BeginnerCorporation()).name) {
+        return new BeginnerCorporation();
+    }
+    let cardFactory = ALL_CORPORATION_CARDS.find((cardFactory) => cardFactory.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_PRELUDE_CORPORATIONS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_VENUS_CORPORATIONS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_COLONIES_CORPORATIONS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_PROMO_CORPORATIONS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    cardFactory = ALL_TURMOIL_CORPORATIONS.find((cf) => cf.cardName === cardName);
+    if (cardFactory !== undefined) {
+        return new cardFactory.factory();
+    }
+    return undefined;
+}
+
+export class Dealer implements ILoadable<SerializedDealer, Dealer>{
     public deck: Array<IProjectCard> = [];
     public preludeDeck: Array<IProjectCard> = [];
     public discarded: Array<IProjectCard> = [];
@@ -876,5 +936,28 @@ export class Dealer {
             throw "Unexpected empty prelude deck";
         }
         return result;
+    }
+
+    // Function used to rebuild each objects
+    public loadFromJSON(d: SerializedDealer): Dealer {
+        // Assign each attributes
+        let o = Object.assign(this, d);
+
+        // Rebuild deck
+        this.deck = d.deck.map((element: IProjectCard)  => {
+            return getProjectCardByName(element.name)!;
+        });
+
+        // Rebuild prelude deck
+        this.preludeDeck = d.preludeDeck.map((element: IProjectCard)  => {
+            return getProjectCardByName(element.name)!;
+        });
+
+        // Rebuild the discard
+        this.discarded = d.discarded.map((element: IProjectCard)  => {
+            return getProjectCardByName(element.name)!;
+        });
+        
+        return o;
     }
 }

--- a/src/ILoadable.ts
+++ b/src/ILoadable.ts
@@ -1,0 +1,3 @@
+export interface ILoadable<T,T2> {
+    loadFromJSON(d: T): T2;
+}

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -32,11 +32,15 @@ import {SelectCity} from "./interrupts/SelectCity";
 import {SpaceType} from "./SpaceType";
 import {ITagCount} from "./ITagCount";
 import {TileType} from "./TileType";
+import {getProjectCardByName, getCorporationCardByName} from "./Dealer";
+import {ILoadable} from "./ILoadable";
+import {Database} from "./database/Database";
+import {SerializedPlayer} from "./SerializedPlayer";
 import {LogMessageType} from "./LogMessageType";
 import {LogMessageData} from "./LogMessageData";
 import {LogMessageDataType} from "./LogMessageDataType";
 
-export class Player {
+export class Player implements ILoadable<SerializedPlayer, Player>{
     public corporationCard: CorporationCard | undefined = undefined;
     public id: string;
     public canUseHeatAsMegaCredits: boolean = false;
@@ -1547,6 +1551,19 @@ export class Player {
       });
     }
 
+    // Propose a new action to undo last action
+    private undoTurnOption(game: Game): PlayerInput {
+      return new SelectOption("Undo Turn", () => {
+        try {
+          Database.getInstance().restoreLastSave(game.id, game.lastSaveId, game);
+        }
+        catch(error){
+          console.log(error);
+        }
+        return undefined;
+      });
+    }
+
     public takeActionForFinalGreenery(game: Game): void {
       if (game.canPlaceGreenery(this)) {
         const action: OrOptions = new OrOptions();
@@ -1836,6 +1853,11 @@ export class Player {
         action.options.push(remainingAwards);
       }
 
+      // Propose undo action only if you have done one action this turn
+      if (this.actionsTakenThisRound > 0) {
+        action.options.push(this.undoTurnOption(game));
+      }
+
       action.options.sort((a, b) => {
         if (a.title > b.title) {
           return 1;
@@ -1878,4 +1900,51 @@ export class Player {
       this.waitingFor = input;
       this.waitingForCb = cb;
     }
+
+    // Function used to rebuild each objects
+    public loadFromJSON(d: SerializedPlayer): Player {
+      // Assign each attributes
+      let o = Object.assign(this, d);
+
+      // Rebuild generation played map
+      this.generationPlayed = new Map<string, number>(d.generationPlayed);
+
+      // action this generation set
+      this.actionsThisGeneration = new Set<string>(d.actionsThisGeneration);
+
+      // Rebuild corporation card
+      if (d.corporationCard !== undefined) {
+        this.corporationCard = getCorporationCardByName(d.corporationCard.name);
+      } else {
+          this.corporationCard = undefined;
+      }
+
+      // Rebuild deal corporation array
+      this.dealtCorporationCards = d.dealtCorporationCards.map((element: CorporationCard)  => {
+        return getCorporationCardByName(element.name)!;
+      });
+
+      // Rebuild each cards in hand
+      this.cardsInHand = d.cardsInHand.map((element: IProjectCard)  => {
+        return getProjectCardByName(element.name)!;
+      });
+
+      // Rebuild each prelude in hand
+      this.preludeCardsInHand = d.preludeCardsInHand.map((element: IProjectCard)  => {
+        return getProjectCardByName(element.name)!;
+      });
+
+      // Rebuild each playerd card
+      this.playedCards = d.playedCards.map((element: IProjectCard)  => {
+        return getProjectCardByName(element.name)!;
+      });
+
+      // Rebuild each drafted cards
+      this.draftedCards = d.draftedCards.map((element: IProjectCard)  => {
+        return getProjectCardByName(element.name)!;
+      });
+      
+      return o;
+    }
 }
+

--- a/src/SerializedDealer.ts
+++ b/src/SerializedDealer.ts
@@ -1,0 +1,10 @@
+import { IProjectCard } from "./cards/IProjectCard";
+
+export interface SerializedDealer {
+    deck: Array<IProjectCard>;
+    preludeDeck: Array<IProjectCard>;
+    discarded: Array<IProjectCard>;
+    usePreludeExtension: boolean;
+    useVenusNextExtension: boolean;   
+    useColoniesNextExtension: boolean;
+}

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -1,0 +1,57 @@
+import {Player} from "./Player";
+import {IProjectCard} from "./cards/IProjectCard";
+import {Phase} from "./Phase";
+import {ClaimedMilestone} from "./ClaimedMilestone";
+import {FundedAward} from "./FundedAward";
+import {IMilestone} from "./milestones/IMilestone";
+import {IAward} from "./awards/IAward";
+import {IColony} from "./colonies/Colony";
+import {ColonyDealer} from "./colonies/ColonyDealer";
+import {PlayerInterrupt} from "./interrupts/PlayerInterrupt";
+import {Board} from "./Board";
+import { CardName } from "./CardName";
+import { BoardName } from "./BoardName";
+import { SerializedPlayer } from "./SerializedPlayer";
+import { SerializedDealer } from "./SerializedDealer";
+
+export interface SerializedGame {
+    id: string;
+    players: Array<SerializedPlayer>;
+    first: Player;
+    preludeExtension: boolean;
+    draftVariant: boolean;
+    showOtherPlayersVP: boolean;
+    venusNextExtension: boolean;
+    coloniesExtension: boolean;
+    customCorporationsList: boolean;
+    corporationList: Array<CardName>;
+    boardName: BoardName;
+    seed?: number
+    activePlayer: Player;
+    claimedMilestones: Array<ClaimedMilestone>;
+    milestones: Array<IMilestone>;
+    dealer: SerializedDealer;
+    fundedAwards: Array<FundedAward>;
+    awards: Array<IAward>;
+    generation: number;
+    draftRound: number;
+    phase: Phase;
+    donePlayers: Set<Player>;
+    oxygenLevel: number;
+    venusScaleLevel: number;
+    passedPlayers: Set<Player>;
+    researchedPlayers: Set<Player>;
+    draftedPlayers: Set<Player>;
+    board: Board;
+    temperature: number;
+    gameLog: Array<String>;
+    gameAge: number;
+    unDraftedCards: Map<Player, Array<IProjectCard>>;
+    interrupts: Array<PlayerInterrupt>;
+    monsInsuranceOwner: Player | undefined;
+    colonies: Array<IColony>;
+    colonyDealer: ColonyDealer | undefined;
+    pendingOceans: number;
+    lastSaveId: number;
+}
+

--- a/src/SerializedPlayer.ts
+++ b/src/SerializedPlayer.ts
@@ -1,0 +1,51 @@
+import {IProjectCard} from "./cards/IProjectCard";
+import {CorporationCard} from "./cards/corporation/CorporationCard";
+import {PlayerInput} from "./PlayerInput";
+import {Color} from "./Color";
+import {VictoryPointsBreakdown} from "./VictoryPointsBreakdown";
+
+export interface SerializedPlayer {
+    corporationCard: CorporationCard | undefined;
+    id: string;
+    name: string;
+    color: Color;
+    beginner: boolean;
+    canUseHeatAsMegaCredits: boolean;
+    plantsNeededForGreenery: number;
+    dealtCorporationCards: Array<CorporationCard>;
+    powerPlantCost: number;
+    titaniumValue: number;
+    steelValue: number;
+    megaCredits: number;
+    megaCreditProduction: number;
+    steel: number;
+    titanium: number;
+    energy: number;
+    steelProduction: number;
+    titaniumProduction: number;
+    energyProduction: number;
+    heat: number;
+    heatProduction: number;
+    plants: number;
+    plantProduction: number;
+    cardsInHand: Array<IProjectCard>;
+    preludeCardsInHand: Array<IProjectCard>;    
+    playedCards: Array<IProjectCard>;
+    draftedCards: Array<IProjectCard>;
+    generationPlayed: Map<string, number>;
+    actionsTakenThisRound: number;
+    terraformRating: number;
+    terraformRatingAtGenerationStart: number;
+    victoryPointsBreakdown: VictoryPointsBreakdown;
+    actionsThisGeneration: Set<string>;
+    lastCardPlayed: IProjectCard | undefined;
+    waitingFor?: PlayerInput;
+    waitingForCb?: () => void;
+    cardCost: number;
+    oceanBonus: number;
+    fleetSize: number;
+    tradesThisTurn: number;
+    colonyTradeOffset: number;
+    colonyTradeDiscount: number;
+}
+

--- a/src/colonies/ColonyDealer.ts
+++ b/src/colonies/ColonyDealer.ts
@@ -10,24 +10,41 @@ import { Io } from './Io';
 import { Miranda } from './Miranda';
 import { Pluto } from './Pluto';
 import { Enceladus } from './Enceladus';
+import { ColonyName } from './ColonyName';
+
+export interface IColonyFactory<T> {
+    colonyName: ColonyName;
+    factory: new () => T
+}
+
+// ALL COLONIES TILES is now a const not and attribute of Colony Dealer
+export const ALL_COLONIES_TILES: Array<IColonyFactory<IColony>> = [
+    { colonyName: ColonyName.CERES, factory: Ceres },
+    { colonyName: ColonyName.ENCELADUS, factory: Enceladus },
+    { colonyName: ColonyName.EUROPA, factory: Europa },
+    { colonyName: ColonyName.GANYMEDE, factory: Ganymede },
+    { colonyName: ColonyName.IO, factory: Io },
+    { colonyName: ColonyName.LUNA, factory: Luna },
+    { colonyName: ColonyName.MIRANDA, factory: Miranda },
+    { colonyName: ColonyName.TITAN, factory: Titan },
+    { colonyName: ColonyName.CALLISTO, factory: Callisto },
+    { colonyName: ColonyName.PLUTO, factory: Pluto },
+    { colonyName: ColonyName.TRITON, factory: Triton },
+];
+
+// Function to return a card object by its name
+export function getColonyByName(colonyName: string): IColony | undefined {
+    let colonyFactory = ALL_COLONIES_TILES.find((colonyFactory) => colonyFactory.colonyName === colonyName);
+    if (colonyFactory !== undefined) {
+        return new colonyFactory.factory();
+    }
+    return undefined;
+}
 
 export class ColonyDealer {
     //private seed: number = 0;
     public coloniesDeck: Array<IColony> = [];
     public discardedColonies: Array<IColony> = [];
-    private ALL_COLONIES_TILES: Array<IColony> = [
-        new Ceres(),
-        new Enceladus(),
-        new Europa(),
-        new Ganymede(),
-        new Io(),
-        new Luna(),
-        new Miranda(),
-        new Titan(),
-        new Callisto(),
-        new Pluto(),
-        new Triton()
-    ];
     /*
     constructor(seed?: number) {
         if (seed !== undefined) {
@@ -58,7 +75,7 @@ export class ColonyDealer {
         } else if (players === 2) {
             count = 5;
         }
-        let tempDeck = this.shuffle(this.ALL_COLONIES_TILES);
+        let tempDeck = this.shuffle(ALL_COLONIES_TILES.map((cf) => new cf.factory()));
         for (let i = 0; i < count; i++) {
             this.coloniesDeck.push(tempDeck.pop());
         }    

--- a/src/components/OtherPlayer.ts
+++ b/src/components/OtherPlayer.ts
@@ -14,7 +14,6 @@ export const OtherPlayer = Vue.component("other-player", {
         "player-resources": PlayerResources,
         "stacked-cards": StackedCards,
         "tag-count": TagCount
-
     },
     mixins: [PlayerMixin],
     methods: {
@@ -33,7 +32,7 @@ export const OtherPlayer = Vue.component("other-player", {
                 <h4>Player «{{ player.name }}» details</h4>
                 
                 <div class="player_home_block">
-                    Cards In Hand: {{player.cardsInHandNbr}}
+                    Cards In Hand: {{player.cardsInHandNbr}} - Event cards: {{ getEventCount() }}
                 </div>
 
                 <div class="tag-display tags_item_cont tag-display-tags" v-if="player.tags.length > 0">

--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -1,0 +1,17 @@
+import { SQLite } from "./SQLite";
+import { IDatabase } from "./IDatabase";
+
+export class Database {
+    private static instance: IDatabase;
+
+    private constructor() {}
+  
+    public static getInstance() {
+        if (!Database.instance) {
+            Database.instance = new SQLite();
+        }
+
+        return Database.instance;
+    }
+  
+  }

--- a/src/database/IDatabase.ts
+++ b/src/database/IDatabase.ts
@@ -1,0 +1,7 @@
+import {Game} from "../Game";
+
+export interface IDatabase {
+    cleanSaves(game_id: string, save_id: number): void;
+    restoreLastSave(game_id: string, save_id: number, game: Game): void;
+    saveGameState(game_id: string, save_id: number, game: string): void;
+}

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -1,0 +1,53 @@
+import { IDatabase } from "./IDatabase";
+import {Game} from "../Game";
+
+import sqlite3 = require("sqlite3");
+const path = require("path");
+const fs = require("fs");
+const dbFolder = path.resolve(__dirname, "../../../db")
+const dbPath = path.resolve(__dirname, "../../../db/game.db");
+
+export class SQLite implements IDatabase {
+    private db: sqlite3.Database;
+    
+    constructor() {
+        // Create the table that will store every saves if not exists
+        if (!fs.existsSync(dbFolder)){
+            fs.mkdirSync(dbFolder);
+        }
+        this.db = new sqlite3.Database(dbPath);
+        this.db.run("CREATE TABLE IF NOT EXISTS games(game_id varchar, save_id integer, game text, PRIMARY KEY (game_id, save_id))");
+    }
+
+    cleanSaves(game_id: string, save_id: number): void {
+        // DELETE all saves expect last one
+        this.db.run("DELETE FROM games WHERE game_id = ? AND save_id < ?", [game_id, save_id], function(err: { message: any; }) {
+            if (err) {
+            return console.warn(err.message);  
+            }
+        });
+    }
+    restoreLastSave(game_id: string, save_id: number, game: Game): void {
+        // Retrieve last save from database
+        this.db.get("SELECT game game FROM games WHERE game_id = ? AND save_id = ? ORDER BY save_id DESC LIMIT 1", [game_id, save_id],(err: { message: any; }, row: { game: any; }) => {
+            if (err) {
+            return console.error(err.message);
+            }
+            // Transform string to json
+            let gameToRestore = JSON.parse(row.game);
+
+            // Rebuild each objects
+            game.loadFromJSON(gameToRestore);
+
+            return true;
+        });
+    }
+    saveGameState(game_id: string, save_id: number, game: string): void {
+        // Insert
+        this.db.run("INSERT INTO games(game_id, save_id, game) VALUES(?, ?, ?)", [game_id, save_id, game], function(err: { message: any; }) {
+            if (err) {
+            return console.log(err.message);  
+            }
+        });
+    }
+}

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -75,7 +75,7 @@
  /* Reduce all cards size */
  .preferences_small_cards .filterDiv {
     transform: scale(0.8);
-    margin: -22px -15px 0 -15px;
+    margin: -22px -15px 10px -15px;
  }
 
  /* Hide blocks */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
     "src/colonies/*.ts",
     "script.ts",
     "server.ts",
-    "src/interrupts/*.ts"
+    "src/interrupts/*.ts",
+    "src/database/*.ts"
   ],
   "files": [
     "script.ts",


### PR DESCRIPTION
* Modify other player board

* Layour changes: correct stacked

* Merge from head

* Add sqlite

* Add save and undo last action. Colonies still need to be implemented

* Mons Insurance

* Implement Colonies + better db path + correct corporation list

* Add db folder

* Remove db file

* Exclude db folder content

* Only keep last save when the game is over

* Better column naming convention. Add Primary key on game_id+save_id

* Remove unnecessary check

* Create a constant for database path

* Changing var to let

* Using findIndex method instead of mapping first

* Use filter instead to parse all the array

* Use map instead of foreach

* Replace quote by double quote for strings

* Create the table at the begining of the game to run the query only one time per game

* Create db folder if not exists

* Create db folder if not exists

* Implement an interface with loadFromJson function to ensure a standard way

* Quick fix: Implement an interface with loadFromJson function to ensure a standard way

* Prevents check on key by using underscore

* Use map and set constructor instead of foreach

* Protect from undefined corporation card

* Try/Catch on restoreLastSave call

* Colonies are now using factory

* Colonies are now using factory

* Adding limit 1 to retrieve only the last save.

* Database is now a singleton and already prepare for other database engines

* Interface for serialized objects

* Correcting database problem when path doesn't exists

Co-authored-by: vincentneko <vincentneko@gmail.com>